### PR TITLE
RoomList에서 하단의 padding이 잘려보이는 문제를 수정하다.

### DIFF
--- a/app/(tabs)/RoomList.tsx
+++ b/app/(tabs)/RoomList.tsx
@@ -33,6 +33,8 @@ const headerStyles = StyleSheet.create({
 const listStyles = StyleSheet.create({
     listContainer: {
         flexGrow: 1,
+    },
+    contentContainer: {
         padding: 16,
     },
     separator: {
@@ -119,8 +121,12 @@ export default function RoomList() {
                 <View style={listStyles.columnCrossline} />
                 <FlatList
                     data={rooms}
+                    // 컴포넌트 자체의 스타일을 정의합니다.
                     style={listStyles.listContainer}
+                    // 아이템들을 구분할 구분선을 정의합니다.
                     ItemSeparatorComponent={() => <View style={listStyles.separator} />}
+                    // 내용물 컨테이너의 스타일을 정의합니다.
+                    contentContainerStyle={listStyles.contentContainer}
                     renderItem={({ item }) => (
                         // Item 컴포넌트에 전달할 props를 정의합니다.
                         <Item


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/15cf1579-e25a-43b8-ae42-37017fa5e982)
padding을 contentContainerStyle로 스타일을 변경하여 하단에 잘리는 문제를 수정했습니다.